### PR TITLE
Change to run fits for the other two participants in the original study.

### DIFF
--- a/convert_tracking_to_data_mat.py
+++ b/convert_tracking_to_data_mat.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Convert annotated tracking data to the public ``data.mat`` layout.
+
+This script reads ``*_tracking_MasterData.mat`` files from
+``../AnnotatedDataRothkopf/tracking`` and writes files containing ``target``,
+``response``, and ``sigma`` arrays in the format consumed by
+``lqg.io.load_tracking_data``.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import numpy as np
+import scipy.io as spio
+
+# sigma labels in annotated tracking files -> labels expected by data/data.mat
+TRACKING_TO_DATA_MAT_SIGMA = {
+    8: 11,
+    10: 13,
+    13: 17,
+    16: 21,
+    19: 25,
+    22: 29,
+}
+
+
+def _map_sigma_labels(tracking_sigma: np.ndarray) -> np.ndarray:
+    keys = np.array(list(TRACKING_TO_DATA_MAT_SIGMA.keys()))
+    if not np.all(np.isin(tracking_sigma, keys)):
+        bad = np.setdiff1d(np.unique(tracking_sigma), keys)
+        raise ValueError(f"Unexpected sigma values in tracking file: {bad}")
+    out = np.empty(tracking_sigma.shape, dtype=np.uint8)
+    for src, dst in TRACKING_TO_DATA_MAT_SIGMA.items():
+        out[tracking_sigma == src] = dst
+    return out
+
+
+def main() -> None:
+    here = os.path.dirname(os.path.abspath(__file__))
+    default_input_dir = os.path.normpath(
+        os.path.join(here, "../AnnotatedDataRothkopf/tracking")
+    )
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument(
+        "initials",
+        help="Participant initials, e.g. JDB or KLB (reads {initials}_tracking_MasterData.mat)",
+    )
+    parser.add_argument(
+        "--input-dir",
+        default=default_input_dir,
+        help="Directory containing *_tracking_MasterData.mat",
+    )
+    parser.add_argument(
+        "--output",
+        default="",
+        help="Output .mat path (default: data/data_{initials}.mat)",
+    )
+    args = parser.parse_args()
+
+    initials = args.initials.strip().upper()
+    in_path = os.path.join(args.input_dir, f"{initials}_tracking_MasterData.mat")
+    if not os.path.isfile(in_path):
+        print(f"ERROR: missing input: {in_path}", file=sys.stderr)
+        sys.exit(1)
+
+    out_path = args.output or os.path.join(here, "data", f"data_{initials}.mat")
+
+    raw = spio.loadmat(in_path, struct_as_record=False, squeeze_me=True)
+    tracking_data = raw["trkData"]
+    target = np.asarray(tracking_data.hTargCoords, dtype=np.float64)
+    response = np.asarray(tracking_data.hRespCoords, dtype=np.uint16)
+    sigma_tracking = np.asarray(tracking_data.sigma)
+    sigma = _map_sigma_labels(sigma_tracking)
+
+    os.makedirs(os.path.dirname(os.path.abspath(out_path)) or ".", exist_ok=True)
+    spio.savemat(
+        out_path,
+        {"target": target, "response": response, "sigma": sigma},
+        do_compression=True,
+    )
+    print(f"Wrote {out_path}  trials={target.shape[0]}  time={target.shape[1]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/cpp_data_fit.py
+++ b/cpp_data_fit.py
@@ -1,4 +1,6 @@
 import argparse
+import os
+
 import numpyro
 from numpyro.infer import MCMC, NUTS, init_to_median
 from jax import random
@@ -31,18 +33,37 @@ def parse_args(args=None, namespace=None):
                         default=["action_variability", "action_cost", "sigma_cursor",
                                  "subj_noise", "subj_vel_noise"],
                         help="Parameters of the model to be shared across conditions")
+    parser.add_argument("--output-basename", dest="output_basename", type=str, 
+                       default="", metavar="NAME", 
+                       help="Basename (no .nc) for data/processed/{NAME}.nc (default: {model}-{seed})")
+    parser.add_argument("--data-mat", dest="data_mat", type=str, 
+                        default="data.mat", metavar="FILE", 
+                        help="Mat file name under data/ or an explicit path (absolute or relative)")
     args = parser.parse_args(args=args, namespace=namespace)
 
     model_params = get_model_params(getattr(tracking, args.model)).keys()
 
     args.shared_params = [p for p in args.shared_params if p in list(model_params)]
-    return parser.parse_args()
+    return args
 
 
 if __name__ == '__main__':
     args = parse_args()
 
-    data, bws = load_tracking_data(delay=args.delay, clip=args.clip, subtract_mean=False)
+    data_mat = args.data_mat
+    if os.path.isabs(data_mat) or os.path.dirname(data_mat):
+        data_path, mat_filename = os.path.split(data_mat)
+        data_path = data_path or "."
+    else:
+        data_path, mat_filename = "data", data_mat
+
+    data, bws = load_tracking_data(
+        delay=args.delay,
+        clip=args.clip,
+        subtract_mean=False,
+        data_path=data_path,
+        mat_filename=mat_filename,
+    )
 
     print(data.shape)
 
@@ -51,5 +72,6 @@ if __name__ == '__main__':
     mcmc = MCMC(nuts_kernel, num_warmup=args.nburnin, num_samples=args.nsamp, num_chains=args.nchain)
     mcmc.run(random.PRNGKey(args.seed), data, getattr(tracking, args.model), shared_params=args.shared_params)
 
-    inference_data = az.convert_to_inference_data(mcmc)
-    inference_data.to_netcdf(f"data/processed/{args.model}-{args.seed}.nc")
+    inference_data = az.from_numpyro(mcmc)
+    out_path = os.path.join("data", "processed", f"{args.output_basename}.nc")
+    inference_data.to_netcdf(out_path)

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,60 @@ The notebooks in the [documentation](https://rothkopflab.github.io/lqg/tutorials
 - [`Overview`](https://rothkopflab.github.io/lqg/tutorials/overview/) explains the model and its parameters in more detail, including the extension to subjective internal models (based on [my tutorial at CCN 2022](https://www.youtube.com/watch?v=3DbO9n6_mNE))
 - [`Data`](https://rothkopflab.github.io/lqg/tutorials/data/) applies the method to data from a tracking experiment
 
+## Running fits for the remaining two participants
+1. Generate participant `.mat` files from annotated tracking data in the same layout as `data/data.mat`:
+
+```bash
+poetry run python convert_tracking_to_data_mat.py JDB
+poetry run python convert_tracking_to_data_mat.py KLB
+```
+
+By default, the script reads from `../AnnotatedDataRothkopf/tracking` and writes to `data/data_JDB.mat` and `data/data_KLB.mat`.
+
+2. Quick smoke test (tiny MCMC on LKC) to verify the fit script runs end-to-end:
+
+```bash
+poetry run python cpp_data_fit.py \
+  --delay 12 \
+  --clip 180 \
+  --nsamp 1 \
+  --nburnin 1 \
+  --nchain 4 \
+  --seed 0 \
+  --model BoundedActor \
+  --data-mat data.mat \
+  --output-basename smoke-LKC \
+  --shared_params
+```
+
+3. Run the full no-shared-parameter fits for the two remaining participants:
+
+```bash
+poetry run python cpp_data_fit.py \
+  --delay 12 \
+  --clip 180 \
+  --nsamp 2500 \
+  --nburnin 1000 \
+  --nchain 4 \
+  --seed 0 \
+  --model BoundedActor \
+  --data-mat data_JDB.mat \
+  --output-basename BoundedActor-0-JDB \
+  --shared_params
+
+poetry run python cpp_data_fit.py \
+  --delay 12 \
+  --clip 180 \
+  --nsamp 2500 \
+  --nburnin 1000 \
+  --nchain 4 \
+  --seed 0 \
+  --model BoundedActor \
+  --data-mat data_KLB.mat \
+  --output-basename BoundedActor-0-KLB \
+  --shared_params
+```
+
 ## Citation
 If you use our method or code in your research, please cite our paper:
 

--- a/lqg/io.py
+++ b/lqg/io.py
@@ -1,4 +1,6 @@
 import os
+import warnings
+
 import numpy as np
 import scipy.io as spio
 
@@ -42,13 +44,21 @@ def _todict(matobj):
     return dict
 
 
-def load_tracking_data(delay=12, clip=120, subtract_mean=True, data_path="data/"):
+def load_tracking_data(
+    delay=12,
+    clip=120,
+    subtract_mean=True,
+    data_path="data/",
+    mat_filename="data.mat",
+):
     """ Load tracking data from Bonnen et al. (2015)
 
     Args:
         delay: temporal delay between target and response
         clip: clip the first n time steps
         subtract_mean: subtract the mean of both trajectories?
+        data_path: directory containing the .mat file
+        mat_filename: file name under ``data_path`` (e.g. ``data.mat``, ``data_JDB.mat``)
 
     Returns:
         np.array: data from tracking task
@@ -58,7 +68,7 @@ def load_tracking_data(delay=12, clip=120, subtract_mean=True, data_path="data/"
     arcscale = 1.32
 
     # load matlab file
-    mat = loadmat(os.path.join(data_path, "data.mat"))
+    mat = loadmat(os.path.join(data_path, mat_filename))
 
     # get target blob widths
     sigma = (mat["sigma"] * arcscale).round()
@@ -82,12 +92,25 @@ def load_tracking_data(delay=12, clip=120, subtract_mean=True, data_path="data/"
         target = target - np.mean(target, axis=1, keepdims=True)
         mouse = mouse - np.mean(mouse, axis=1, keepdims=True)
 
-    # stack data from all trials
-    data = np.stack(
-        [np.array(
-            [target[np.where(sigma == blob_width)[0], :],
-             mouse[np.where(sigma == blob_width)[0], :]])
-            for blob_width in sigmas])
+    # Per-condition blocks: shape (2, n_trials_c, T). np.stack requires identical n_trials_c.
+    blocks = []
+    for blob_width in sigmas:
+        idx = np.where(sigma == blob_width)[0]
+        blocks.append(
+            np.array([target[idx, :], mouse[idx, :]])
+        )
+    trial_counts = [b.shape[1] for b in blocks]
+    m = min(trial_counts)
+    if max(trial_counts) != m:
+        warnings.warn(
+            f"Unequal trials per blob condition {trial_counts}; "
+            f"using the first {m} trials per condition so the LQG array stacks.",
+            UserWarning,
+            stacklevel=2,
+        )
+        blocks = [b[:, :m, :] for b in blocks]
+
+    data = np.stack(blocks)
 
     # bring in right shape for our analysis methods
     data = data.transpose(0, 2, 3, 1)


### PR DESCRIPTION
For this PR, I tried making a little changes to the current state of the upstream branch. Just enough to get the fits for the other two participants to run.

Add script to convert annotated tracking data to data.mat format

If conditions have unequal trials, `io.py` now automatically drops the extra ones. This commit introduces a new script, `convert_tracking_to_data_mat.py`, which converts annotated tracking data from `*_tracking_MasterData.mat` files into the `data.mat` format used by the project. The script includes functionality to map sigma labels and handles input/output paths. Additionally, updates were made to `cpp_data_fit.py` to allow for custom data.mat file paths and to improve output handling. The README was also updated with instructions for generating participant .mat files and running fits.